### PR TITLE
fix app msg display & js version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ wechatircd类似于bitlbee，在微信网页版和IRC间建起桥梁，可以使
 Chrome/Chromium
 
 - 访问`chrome://settings/certificates`，导入a.crt，在Authorities标签页选择该证书，Edit->Trust this certificate for identifying websites.
-- 安装Switcheroo Redirector扩展，把<https://res.wx.qq.com/zh_CN/htmledition/v2/js/webwxApp2e4e03.js>重定向至<https://127.0.0.1:9000/webwxapp.js>。若js更新，该路径会变化。
+- 安装Switcheroo Redirector扩展，把<https://res.wx.qq.com/zh_CN/htmledition/v2/js/webwxApp2fd632.js>重定向至<https://127.0.0.1:9000/webwxapp.js>。若js更新，该路径会变化。
 
 Firefox
 

--- a/webwxapp.js
+++ b/webwxapp.js
@@ -2846,8 +2846,8 @@ angular.module("Services", []),
                                     if (e.AppMsgType == confFactory.APPMSGTYPE_ATTACH) {
                                         content = `[文件] filename: ${e.FileName} size: ${e.MMAppMsgFileSize} url: ${e.MMAppMsgDownloadUrl}`
                                     } else {
-                                        var appmsg = $.parseHTML(content.replace(/&lt;?/g,'<').replace(/&gt;?/g,'>').replace(/&amp;?/g,'&'))[0]
-                                        content = '[App] ' + $('title', appmsg).text() + ' ' + $('url', appmsg).text()
+                                        var doms = $.parseHTML(content.replace(/&lt;?/g,'<').replace(/&gt;?/g,'>').replace(/&amp;?/g,'&'))
+                                        content = '[App] ' + $('appmsg>title', doms).text() + ' ' + $('appmsg>url', doms).text()
                                     }
                                 }
                                 else if (e.MsgType == confFactory.MSGTYPE_MICROVIDEO) // 62 小视频

--- a/wechatircd.py
+++ b/wechatircd.py
@@ -47,6 +47,7 @@ class Web(object):
         Web.instance = self
 
     async def handle_webwxapp_js(self, request):
+        info("Serving webwxapp.js ...")
         with open(os.path.join(self.http_root, 'webwxapp.js'), 'rb') as f:
             return web.Response(body=f.read(),
                                 headers={'Content-Type': 'application/javascript; charset=UTF-8',


### PR DESCRIPTION
I see that:

``` js
appmsg = parseHTML(content)[0]
```

gave a result of `<xml version = xxx/>` but `parseHTML(content)[2]` contains the actual appmsg.
This fix will search in all nodes in content.
